### PR TITLE
Make logo clickable to navigate to dashboard

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,6 @@
   "permissions": {
     "allow": [
       "WebSearch",
-      "mcp__firebase__firestore_list_collections",
       "WebFetch(domain:github.com)",
       "mcp__context7__resolve-library-id"
     ],

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+    "scripts": {
+        "setup": "npm install",
+        "run": "npm start"
+    }
+}

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -1,9 +1,11 @@
 import NavElement from "./NavElement";
 import { useAuth } from "../../contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
 import { Building2, User } from "lucide-react";
 
 function Nav({ navElements }) {
     const { user, role } = useAuth();
+    const navigate = useNavigate();
 
     // Get user initials for avatar
     const getUserInitials = () => {
@@ -16,21 +18,31 @@ function Nav({ navElements }) {
         return email.substring(0, 2).toUpperCase();
     };
 
+    // Navigate to appropriate dashboard based on role
+    const handleLogoClick = () => {
+        const dashboardPath = role === 'manager' ? '/manager/dashboard' : '/tenant/dashboard';
+        navigate(dashboardPath);
+    };
+
     return (
         <nav className="fixed w-315 h-screen bg-white border-r border-secondary-100 flex flex-col shadow-sm">
             {/* Logo and Brand */}
             <div className="px-6 py-6 border-b border-secondary-100">
-                <div className="flex items-center gap-3">
+                <button
+                    onClick={handleLogoClick}
+                    className="flex items-center gap-3 w-full cursor-pointer hover:opacity-80 transition-opacity duration-200 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded-lg p-1 -m-1"
+                    aria-label="Go to dashboard"
+                >
                     <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-gradient-to-br from-primary-500 to-primary-700 shadow-md">
                         <Building2 size={24} className="text-white" />
                     </div>
-                    <div>
+                    <div className="text-left">
                         <h1 className="text-xl font-bold text-secondary-900 leading-none mb-0.5">Villa</h1>
                         <p className="text-xs text-secondary-500 capitalize leading-none">
                             {role || 'User'} Portal
                         </p>
                     </div>
-                </div>
+                </button>
             </div>
 
             {/* Navigation Items */}


### PR DESCRIPTION
## Summary
- Made the Villa logo in the navigation bar clickable
- Clicking the logo navigates users to their role-specific dashboard (tenant or manager)
- Added hover effects to indicate interactivity
- Included proper accessibility attributes (aria-label, keyboard focus)

## Test plan
- [x] Click logo as a tenant user and verify navigation to `/tenant/dashboard`
- [x] Click logo as a manager user and verify navigation to `/manager/dashboard`
- [x] Verify hover effect shows on logo
- [x] Test keyboard navigation (Tab to logo, Enter to activate)
- [x] Verify focus ring appears when logo is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)